### PR TITLE
fix(gen-config-file): yuque-pwd缺少引号

### DIFF
--- a/packages/cli/src/utils/gen-config-file.ts
+++ b/packages/cli/src/utils/gen-config-file.ts
@@ -11,7 +11,7 @@ const configJsStr =
   '      onlyPublic: false,\n' +
   '      onlyPublished: true,\n' +
   '    },\n' +
-  '    yuque-pwd: {\n' +
+  "    'yuque-pwd': {\n" +
   '      username: process.env.YUQUE_USERNAME,\n' +
   '      password: process.env.YUQUE_PASSWORD,\n' +
   '      login: process.env.YUQUE_LOGIN,\n' +


### PR DESCRIPTION
gen-config-file生成的是 yuque-pwd，每次生成后需要自己手动添加引号'yuque-pwd'