### PR TITLE
发布到halo平台时添加创建时间和发布时间

### DIFF
--- a/packages/deploy/src/platform/halo.ts
+++ b/packages/deploy/src/platform/halo.ts
@@ -229,6 +229,9 @@ class DeployHalo {
             cover: '',
             deleted: false,
             publish: false,
+            publishTime: doc.properties.date
+              ? new Date(doc.properties.date).toISOString()
+              : new Date().toISOString(),
             pinned: false,
             allowComment: true,
             visible: PostSpecVisibleEnum.Public,
@@ -245,6 +248,9 @@ class DeployHalo {
           kind: 'Post',
           metadata: {
             name: doc.doc_id,
+            creationTimestamp: doc.properties.date
+              ? new Date(doc.properties.date).toISOString()
+              : new Date().toISOString(),
           },
         },
         content: {
@@ -261,6 +267,11 @@ class DeployHalo {
           raw: '',
           content: '',
           rawType: 'html',
+        }
+        // 如果存在日期属性，更新现有帖子的创建时间戳
+        if (doc.properties.date) {
+          params.post.spec.publishTime = new Date(doc.properties.date).toISOString()
+          params.post.metadata.creationTimestamp = new Date(doc.properties.date).toISOString()
         }
       }
       // 覆盖文档标题


### PR DESCRIPTION
发布到Halo平台的时候，发布的时间默认是上传的时间，本次修改成读取文章的date字段，如果有，则使用，没有则用当前时间

<img width="331" alt="image" src="https://github.com/user-attachments/assets/1a6e0ce0-39c1-4382-bea8-c39b1b8c3027" />
